### PR TITLE
Fix a buffer overflow and a minor bug

### DIFF
--- a/functions/InlineHelper_dialog.cpp
+++ b/functions/InlineHelper_dialog.cpp
@@ -8,7 +8,7 @@ static char g_szTargetDir[256]=""; 		// String for the directory of the debugged
 
 static bool g_FileIsDll=false; 					// Flag for DLL
 
-static char g_codeText[2048]=""; 			// String for the inline asm code
+static char g_codeText[4096]=""; 			// String for the inline asm code
 
 static IH_InlineHelperData_t g_TargetData;
 

--- a/functions/Misc_dialog.cpp
+++ b/functions/Misc_dialog.cpp
@@ -584,7 +584,7 @@ BOOL CALLBACK MSC_DlgMain(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 UpdateHorizontalScrollLen(list, "");
             //TODO: remove this
             char command[256]="";
-            sprintf(command, "start %s INFO", MSC_szFileName);
+            sprintf(command, "\"%s\" INFO", MSC_szFileName);
             system(command);
         }
         return TRUE;


### PR DESCRIPTION
- Fixed a buffer overflow in the InlineHelper: g_codeText was too small, so once filled the inlining code used to overwrite nearby variables
- If the path where the target exe lived contained a space the INFO command run after the removal of the license used to fail. Fixed.
