### PR TITLE
Wininet now gets in the way...

### DIFF
--- a/new_inline_templ.asm
+++ b/new_inline_templ.asm
@@ -13,6 +13,25 @@ ret
 pop eax
 mov dword ptr ds:[eax+1],ebp
 ;imagebase stuff
+;imagesize stuff
+call @f
+@gettopaddress:
+mov ebp,0FFFFFFFF
+ret
+@@:
+call @getimagebase
+mov eax,ebp
+add ebp,03C
+add eax,[ebp]
+add eax,50
+mov eax,[eax]
+call @getimagebase
+add eax,ebp
+xchg eax,ebp
+pop eax
+mov [eax+1],ebp
+;imagesize stuff
+call @getimagebase
 mov ebx, dword ptr ds:[ebp+%X] ; OutputDebugStringA
 mov esi, dword ptr ds:[ebp+%X] ; VirtualProtect
 
@@ -35,16 +54,31 @@ call esi ; VirtualProtect
 ; Hook VirtualProtect
 call @vp_skip
 @vp_original_bytes:
+call @getimagebase ; Verify the call comes from Arma
+cmp [esp+10],ebp
+jb @vp_dontrestoreyet
+call @gettopaddress
+cmp [esp+10],ebp
+ja @vp_dontrestoreyet
 call @f
+@vp_dontrestoreyet:
+pop ebp
+pop ecx
+pop esi
+pop edi
 \"\\x90\\x90\\x90\\x90\\x90\"
+jmp 12345678
 @@:
 jmp short @vp_hook_back
 @vp_skip:
 pop edi
-add edi,5
+add edi,27
 mov ecx,5
 rep movs byte ptr es:[edi],byte ptr ds:[esi]
 sub esi,5
+sub esi,edi
+mov [edi+1],esi
+add esi,edi
 mov byte ptr ds:[esi],0E9
 call @vp_hook_end
 
@@ -56,6 +90,7 @@ push ebp
 jmp short @vp_original_bytes
 @vp_hook_back:
 pop esi
+add esi,4
 call @getimagebase
 mov edi,dword ptr ds:[ebp+%X] ; VirtualProtect
 mov ecx,5


### PR DESCRIPTION
...and the first VirtualProtect doesn't come from Arma anymore.

Check the return address and either:
1 - execute the first bytes of VP using those we have previously saved, then jump to the API if the CALL didn't come from Arma or
2 - behave normally if the CALL came from the inlined module.
